### PR TITLE
feat: Automatically scoop update before toast scoop status. (#28)

### DIFF
--- a/tools/toast-scoop-status.ps1
+++ b/tools/toast-scoop-status.ps1
@@ -21,6 +21,14 @@ $oldPriority = [System.Diagnostics.Process]::GetCurrentProcess().PriorityClass
 try {
     [System.Diagnostics.Process]::GetCurrentProcess().PriorityClass = 'Idle'
 
+    scoop update
+
+    if ($LASTEXITCODE -eq 0) {
+        $update_status_message = ""
+    } else {
+        $update_status_message = "Warning: `scoop status` is failed."
+    }
+
     $status = @(scoop status 6>$null | Where-Object { $_.PSObject.Properties['Name'] })
 
     if ($status) {
@@ -29,8 +37,21 @@ try {
         $title = "Scoop: $num_updatable_apps app updates"
         # Toast body.
         $body = $status.Name -join ', '
+        # Toast detail.
+        $detail = $update_status_message
+    } else {
+        $title = "Scoop: No updates available"
+        $body = $update_status_message
+        $detail = ""
+    }
+
+    if ($title -and $body) {
         # Invoke toast notification.
-        & "$PSScriptRoot\..\toast-cli.ps1" -title $title -body $body
+        if ($detail) {
+            & "$PSScriptRoot\..\toast-cli.ps1" -title $title -body $body -detail $detail
+        } else {
+            & "$PSScriptRoot\..\toast-cli.ps1" -title $title -body $body
+        }
     }
 }
 finally {


### PR DESCRIPTION
Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Status notifications now include the result of the update check, so you’ll see a warning message if updates could not be checked.
  * When updates are available, the toast now shows update-related details more clearly; when none are available, the notification content reflects the update check outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->